### PR TITLE
Improved encoder M0 settings (#69)

### DIFF
--- a/Source/Lib/Codec/EbDefinitions.h
+++ b/Source/Lib/Codec/EbDefinitions.h
@@ -143,6 +143,7 @@ extern "C" {
 #define TX_SEARCH_LEVELS                                1 
 #define INTERPOLATION_SEARCH_LEVELS                     1 
 #define NSQ_SEARCH_LEVELS                               1
+#define TUNED_SETTINGS_FOR_M0                           1
 /********************************************************/
 /****************** Pre-defined Values ******************/
 /********************************************************/


### PR DESCRIPTION
* Improved M0 settings:
70% speed up for the same bdrate.
+ Enable interpolation search in Fast-Loop.
+ Adjusted description of the intra-pred-levels.